### PR TITLE
Downgrade fdroidserver to 2.1-1

### DIFF
--- a/.github/workflows/fdroid.yml
+++ b/.github/workflows/fdroid.yml
@@ -10,17 +10,18 @@ on:
 jobs:
   apps:
     name: "Generate repo from apps listing"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v2
-
       - name: Install system dependencies
         run: |
           sudo add-apt-repository ppa:fdroid/fdroidserver
           sudo apt update
-          sudo apt install fdroidserver git-restore-mtime
+          sudo apt install fdroidserver=2.1-1 git-restore-mtime
           fdroid --version
+
+      - name: Checkout repository 
+        uses: actions/checkout@v2
 
       - name: Create basic directory structure
         run: mkdir -p fdroid/repo
@@ -40,9 +41,7 @@ jobs:
           
       - uses: actions/setup-go@v2
         name: Set up Go
-        with:
-          go-version: '^1.17.0' 
-        
+
       - name: Run update script
         run: bash update.sh 2>&1
         env:


### PR DESCRIPTION
Downgrade fdroidserver to 2.1-1

- Newer fdroidserver 2.4.2 has dependency conflict on Ubuntu 22.04 (jammy)
- Newer fdroidserver 2.4.2 on Ubuntu 24.04 (nobel) does not come with patched androguard which in turn pulls unpatched androguard and nothing works

See https://launchpad.net/~fdroid/+archive/ubuntu/fdroidserver/+packages?field.name_filter=&field.status_filter=published&field.series_filter=noble

Fixes the issue that came back again: https://gitlab.com/fdroid/docker-executable-fdroidserver/-/issues/28